### PR TITLE
Remove that F-Droid only have FOSS apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Feel free to [contribute](https://github.com/theel0ja/foss-android/edit/master/R
 |---------------|--------|
 |Android|[microG fork of LineageOS](https://lineage.microg.org/) (if available), [LineageOS](https://lineageos.org/)|
 |[Google Play services](https://en.wikipedia.org/wiki/Google_Play_Services)|[microG](https://microg.org/)|
-|[Google Play Store](https://en.wikipedia.org/wiki/Google_Play)|[F-Droid](https://f-droid.org/en/) (FOSS apps only), [Aurora Store](https://f-droid.org/en/packages/com.dragons.aurora/) or [Yalp Store](https://f-droid.org/packages/com.github.yeriomin.yalpstore/) (free Google Play clients)|
+|[Google Play Store](https://en.wikipedia.org/wiki/Google_Play)|[F-Droid](https://f-droid.org/en/), [Aurora Store](https://f-droid.org/en/packages/com.dragons.aurora/) or [Yalp Store](https://f-droid.org/packages/com.github.yeriomin.yalpstore/) (free Google Play clients)|
 
 ## Must have apps
 


### PR DESCRIPTION
F-Droid support third-party-repositories managed by other people. Maybe big companies. Only the main (and archive) repo builds all from source.